### PR TITLE
Leave internal reader nil if gzip EOF

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -85,7 +85,7 @@ type Config struct {
 	FlushPeriod        time.Duration   `mapstructure:"force_flush_period,omitempty"`
 	Header             *HeaderConfig   `mapstructure:"header,omitempty"`
 	DeleteAfterRead    bool            `mapstructure:"delete_after_read,omitempty"`
-	GzipFileSuffix     string          `mapstructure:"gzip_file_suffix,omitempty"`
+	Compression        string          `mapstructure:"compression,omitempty"`
 }
 
 type HeaderConfig struct {
@@ -167,7 +167,7 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 		Attributes:        c.Resolver,
 		HeaderConfig:      hCfg,
 		DeleteAtEOF:       c.DeleteAfterRead,
-		GzipFileSuffix:    c.GzipFileSuffix,
+		Compression:       c.Compression,
 	}
 
 	var t tracker.Tracker

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -832,8 +832,8 @@ func (c *Config) withHeader(headerMatchPattern, extractRegex string) *Config {
 }
 
 // withGzipFileSuffix is a builder-like helper for quickly setting up support for gzip compressed log files
-func (c *Config) withGzipFileSuffix(suffix string) *Config {
-	c.GzipFileSuffix = suffix
+func (c *Config) withGzip() *Config {
+	c.Compression = "gzip"
 	return c
 }
 

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -1536,7 +1536,7 @@ func TestReadGzipCompressedLogsFromBeginning(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	cfg := NewConfig().includeDir(tempDir).withGzipFileSuffix(".gz")
+	cfg := NewConfig().includeDir(tempDir).withGzip()
 	cfg.StartAt = "beginning"
 	operator, sink := testManager(t, cfg)
 
@@ -1564,7 +1564,7 @@ func TestReadGzipCompressedLogsFromEnd(t *testing.T) {
 	t.Parallel()
 
 	tempDir := t.TempDir()
-	cfg := NewConfig().includeDir(tempDir).withGzipFileSuffix(".gz")
+	cfg := NewConfig().includeDir(tempDir).withGzip()
 	cfg.StartAt = "end"
 	operator, sink := testManager(t, cfg)
 


### PR DESCRIPTION
- Reformulates config option to `compression`
- Refactors gzip reader creation to leave internal reader nil
- Removes custom offset override